### PR TITLE
[FEATURE]  Enable specific branch cloning

### DIFF
--- a/burp.toml
+++ b/burp.toml
@@ -4,7 +4,7 @@
 # This is the official Burp.toml for the Burp deployment tool. You can reference this
 # to see how a Burp.toml would appear.
 #---------------------
-version = 1.0
+version = 1.1
 
 #------------
 # NOTE: When using `bind` with files that only exist on the client-side
@@ -27,7 +27,7 @@ includes = [
 [service]
 name = "burp"
 build = "/"
-repository = "https://github.com/ShindouMihou/burp"
+repository = { link = "https://github.com/ShindouMihou/burp/" }
 restart_policy = { name = "always" }
 volumes = [
     #-----------------------------

--- a/internal/burp/model.go
+++ b/internal/burp/model.go
@@ -1,9 +1,14 @@
 package burp
 
 type Service struct {
-	Build      string `toml:"build" json:"build"`
-	Repository string `toml:"repository" json:"repository"`
+	Build      string     `toml:"build" json:"build"`
+	Repository Repository `toml:"repository" json:"repository"`
 	Container
+}
+
+type Repository struct {
+	Link   string  `toml:"link" json:"link"`
+	Branch *string `toml:"branch,omitempty"  json:"branch,omitempty"`
 }
 
 type Dependency struct {


### PR DESCRIPTION
Burp should allow for more options in cloning a repository, for instance,  cloning a specific branch of the repository. This was one of the faults that were identified while trying to test #2. Due to the scope of this change, it has to be a breaking change which changes the `repository` property from a `string` to a `Repository`.

```go
type Repository struct {
 Link string  `toml:"link"`
 Branch *string `toml:"branch,omitempty"`
}
```