### PR TITLE
[FIX] Looping Routes

### DIFF
--- a/cmd/burp-agent/server/responses/sse.go
+++ b/cmd/burp-agent/server/responses/sse.go
@@ -30,6 +30,7 @@ func Stream(ctx *gin.Context, action StreamingAction) {
 				return
 			default:
 				action(ctx2, channel)
+				cancel()
 			}
 		}
 	}()


### PR DESCRIPTION
As a  side-effect of #1, we ended up having looping routes because the context was not being canceled. This resolves that issue and has been tested.