### PR TITLE
[FEATURE] Removes `insecureSkipVerify`

### DIFF
--- a/burp.toml
+++ b/burp.toml
@@ -27,7 +27,7 @@ includes = [
 [service]
 name = "burp"
 build = "/"
-repository = { link = "https://github.com/ShindouMihou/burp/" }
+repository = { link = "https://github.com/ShindouMihou/burp/", branch = "feat/remove-insecure-skip-verify" }
 restart_policy = { name = "always" }
 volumes = [
     #-----------------------------

--- a/burp.toml
+++ b/burp.toml
@@ -27,7 +27,7 @@ includes = [
 [service]
 name = "burp"
 build = "/"
-repository = { link = "https://github.com/ShindouMihou/burp/", branch = "feat/remove-insecure-skip-verify" }
+repository = { link = "https://github.com/ShindouMihou/burp/" }
 restart_policy = { name = "always" }
 volumes = [
     #-----------------------------

--- a/cmd/burp-agent/server/agent.go
+++ b/cmd/burp-agent/server/agent.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-contrib/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
+	"path/filepath"
 	"strconv"
 )
 
@@ -38,6 +39,7 @@ func Init(port int16) {
 			executioner(app)
 		}
 		app.NoRoute(func(ctx *gin.Context) { responses.NotFound.Reply(ctx) })
+		app.StaticFile("ssl.cert", filepath.Join(TemporarySslDirectory, "ssl.cert"))
 		if err := app.RunTLS(":"+strconv.FormatInt(int64(port), 10), cert, key); err != nil {
 			log.Panic().Err(err).Msg("Cannot Start Gin")
 			return

--- a/cmd/burp-agent/server/middlewares/authentication.go
+++ b/cmd/burp-agent/server/middlewares/authentication.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+var SkipRoutes = []string{"/ssl.cert"}
+
 // Authenticated is a middleware that checks the authentication of a request.
 // It checks for the X-Burp-Signature first before proceeding with the Authorization
 // otherwise known as the Burp Secret.
@@ -17,6 +19,10 @@ import (
 // If it fails in either of the checks, then the middleware will stop them with a 401
 // HTTP status code.
 var Authenticated gin.HandlerFunc = func(ctx *gin.Context) {
+	if utils.AnyMatchString(SkipRoutes, ctx.FullPath()) {
+		ctx.Next()
+		return
+	}
 	signature := ctx.GetHeader("X-Burp-Signature")
 	if signature == "" || signature != env.BurpSignature.Get() {
 		responses.Unauthorized.Reply(ctx)

--- a/cmd/burp-agent/server/ssl.go
+++ b/cmd/burp-agent/server/ssl.go
@@ -3,8 +3,8 @@ package server
 import (
 	"burp/pkg/env"
 	"burp/pkg/fileutils"
+	"burp/pkg/utils"
 	"errors"
-	"github.com/portainer/libcrypto"
 	"github.com/rs/zerolog/log"
 	"os"
 	"path/filepath"
@@ -60,7 +60,8 @@ func GetSsl() (cert string, key string, err error) {
 		return "", "", err
 	}
 	// Thanks Portainer for libcrypto! (CC: https://github.com/portainer/libcrypto)
-	err = libcrypto.GenerateCertsForHost("localhost", "0.0.0.0", certificatePath, keyPath,
+	// Although, we changed it a bit to make it into a root certificate.
+	err = utils.GenerateCertsForHost("localhost", "0.0.0.0", certificatePath, keyPath,
 		time.Now().AddDate(5, 0, 0))
 	if err != nil {
 		return "", "", err

--- a/cmd/burp/api/client.go
+++ b/cmd/burp/api/client.go
@@ -55,6 +55,10 @@ func CreateWithClient(client *resty.Client, secrets *Secrets) *resty.Request {
 		SetAuthToken(secrets.Secret)
 }
 
+func CreateInsecureWith(secrets *Secrets) *resty.Request {
+	return CreateWithClient(InsecureClient, secrets)
+}
+
 func CreateInsecure() *resty.Request {
 	return InsecureClient.R()
 }

--- a/cmd/burp/api/ssl.go
+++ b/cmd/burp/api/ssl.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"burp/cmd/burp-agent/server"
+	"burp/pkg/fileutils"
+	"net/url"
+	"path/filepath"
+)
+
+func SaveCertificate(host string, name string) error {
+	certificateRoute, _ := url.JoinPath(host, "ssl.cert")
+	certificate, err := CreateInsecure().Get(certificateRoute)
+	if err != nil {
+		return err
+	}
+	sslCertificateLocation := filepath.Join(server.TemporarySslDirectory, name, "ssl.cert")
+	if err := fileutils.Save(sslCertificateLocation, certificate.Body()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/burp/commands/deploy.go
+++ b/cmd/burp/commands/deploy.go
@@ -39,8 +39,11 @@ var Deploy = &cli.Command{
 		if !ok {
 			return nil
 		}
-		request := secrets.Client().
-			EnableTrace().
+		client, ok := secrets.ClientWithTls(answers.Keys.Name)
+		if !ok {
+			return nil
+		}
+		request := client.EnableTrace().
 			SetMultipartField("package[]", "burp.toml", "application/toml", bytes.NewReader(flow.Bytes())).
 			SetDoNotParseResponse(true)
 		if ok && environmentFile != nil {

--- a/cmd/burp/commands/here.go
+++ b/cmd/burp/commands/here.go
@@ -66,7 +66,7 @@ var Here = &cli.Command{
 		}()
 		go func() {
 			time.Sleep(5 * time.Second)
-			request := secrets.Client().
+			request := api.CreateInsecure().
 				EnableTrace().
 				SetMultipartField("package[]", "burp.toml", "application/toml", bytes.NewReader(flow.Bytes())).
 				SetDoNotParseResponse(true)

--- a/cmd/burp/commands/here.go
+++ b/cmd/burp/commands/here.go
@@ -66,7 +66,7 @@ var Here = &cli.Command{
 		}()
 		go func() {
 			time.Sleep(5 * time.Second)
-			request := api.CreateInsecure().
+			request := api.CreateInsecureWith(secrets).
 				EnableTrace().
 				SetMultipartField("package[]", "burp.toml", "application/toml", bytes.NewReader(flow.Bytes())).
 				SetDoNotParseResponse(true)

--- a/cmd/burp/commands/login.go
+++ b/cmd/burp/commands/login.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"burp/cmd/burp-agent/server"
 	"burp/cmd/burp/api"
 	"burp/cmd/burp/commands/logins"
 	"burp/pkg/console"
@@ -87,19 +86,6 @@ var Login = &cli.Command{
 		console.Clear()
 		answers.Keys.Sanitize()
 		answers.Secrets.Sanitize()
-		certificateRoute, _ := url.JoinPath(answers.Server, "ssl.cert")
-		certificate, err := api.CreateInsecure().Get(certificateRoute)
-		if err != nil {
-			fmt.Println(chalk.Red, "(◞‸◟；)", chalk.Reset, "We failed to talk it out with Burp! It seems like something happened!")
-			fmt.Println(chalk.Red, err.Error())
-			return nil
-		}
-		sslCertificateLocation := filepath.Join(server.TemporarySslDirectory, answers.Keys.Name, "ssl.cert")
-		if err := fileutils.Save(sslCertificateLocation, certificate.Body()); err != nil {
-			fmt.Println(chalk.Red, "(◞‸◟；)", chalk.Reset, "We failed to talk it out with Burp! It seems like something happened!")
-			fmt.Println(chalk.Red, err.Error())
-			return nil
-		}
 		client, ok := answers.Secrets.ClientWithTls(answers.Keys.Name)
 		if !ok {
 			return nil

--- a/cmd/burp/commands/login.go
+++ b/cmd/burp/commands/login.go
@@ -87,7 +87,8 @@ var Login = &cli.Command{
 		console.Clear()
 		answers.Keys.Sanitize()
 		answers.Secrets.Sanitize()
-		certificate, err := api.CreateInsecure().Get(filepath.Join(answers.Server, "ssl.cert"))
+		certificateRoute, _ := url.JoinPath(answers.Server, "ssl.cert")
+		certificate, err := api.CreateInsecure().Get(certificateRoute)
 		if err != nil {
 			fmt.Println(chalk.Red, "(◞‸◟；)", chalk.Reset, "We failed to talk it out with Burp! It seems like something happened!")
 			fmt.Println(chalk.Red, err.Error())

--- a/cmd/burp/commands/restart.go
+++ b/cmd/burp/commands/restart.go
@@ -29,9 +29,12 @@ var Restart = &cli.Command{
 		if burp == nil || flow == nil {
 			return nil
 		}
+		client, ok := secrets.ClientWithTls(answers.Keys.Name)
+		if !ok {
+			return nil
+		}
 		var createRequest = func() *resty.Request {
-			return secrets.Client().
-				EnableTrace().
+			return client.EnableTrace().
 				SetMultipartField("burp", "burp.toml", "application/toml", bytes.NewReader(flow.Bytes())).
 				SetDoNotParseResponse(true)
 		}

--- a/cmd/burp/commands/templates/server_request.go
+++ b/cmd/burp/commands/templates/server_request.go
@@ -103,8 +103,11 @@ func CreateServerRequestCommand(name string, description string, action ServerRe
 			if burp == nil || flow == nil {
 				return nil
 			}
-			request := secrets.Client().
-				EnableTrace().
+			client, ok := secrets.ClientWithTls(answers.Keys.Name)
+			if !ok {
+				return nil
+			}
+			request := client.EnableTrace().
 				SetMultipartField("burp", "burp.toml", "application/toml", bytes.NewReader(flow.Bytes())).
 				SetDoNotParseResponse(true)
 

--- a/examples/burp.toml
+++ b/examples/burp.toml
@@ -12,7 +12,7 @@ version = 1.0
 [service]
 name = "primrose-backend"
 build = "core/"
-repository = "https://github.com/ShindouMihou/primrose"
+repository = { link = "https://github.com/ShindouMihou/primrose" }
 restart_policy = { name = "always" }
 
 [[dependencies]]

--- a/pkg/utils/ssl.go
+++ b/pkg/utils/ssl.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+// GenerateCertsForHost generates a self-signed certificate for host and saves them at certPath and keyPath
+// CC: https://github.com/portainer/libcrypto
+// This is modified to turn the certificate into a CA root.
+func GenerateCertsForHost(hostname, ip, certPath, keyPath string, expiry time.Time) error {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotAfter:              expiry,
+		NotBefore:             time.Now(),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return errors.New("failed parsing host ip")
+	}
+
+	template.DNSNames = append(template.DNSNames, hostname)
+	template.IPAddresses = append(template.IPAddresses, parsedIP)
+
+	keyPair, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	encodedCert, err := x509.CreateCertificate(rand.Reader, &template, &template, &keyPair.PublicKey, keyPair)
+	if err != nil {
+		return err
+	}
+
+	err = createPEMEncodedFile(certPath, "CERTIFICATE", encodedCert)
+	if err != nil {
+		return err
+	}
+
+	key, err := x509.MarshalECPrivateKey(keyPair)
+	if err != nil {
+		return err
+	}
+
+	err = createPEMEncodedFile(keyPath, "EC PRIVATE KEY", key)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createPEMEncodedFile(path, header string, data []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	err = pem.Encode(file, &pem.Block{Type: header, Bytes: data})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request enables us to remove the use of `insecureSkipVerify` for other than the initial login (where the SSL certificate is retrieved), enabling us to use that certificate to verify that the server's certificate is correct and proper. This does not produce a breaking change since the CLI will automatically fetch the certificate if it doesn't exist.

Closes #2 