### PR TITLE
[FEATURE] Disable request logger when `burp here`

### DIFF
--- a/cmd/burp-agent/server/agent.go
+++ b/cmd/burp-agent/server/agent.go
@@ -3,6 +3,7 @@ package server
 import (
 	"burp/cmd/burp-agent/server/middlewares"
 	"burp/cmd/burp-agent/server/responses"
+	"burp/pkg/env"
 	"github.com/gin-contrib/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -34,7 +35,10 @@ func Init(port int16) {
 		// of Burp is intended for additional configuration files, not massive
 		// dangerous binaries.
 		app.MaxMultipartMemory = 5 << 20
-		app.Use(logger.SetLogger(), middlewares.Authenticated)
+		if env.AgentMode.Or("release") != "local" {
+			app.Use(logger.SetLogger())
+		}
+		app.Use(middlewares.Authenticated)
 		for _, executioner := range Executioners {
 			executioner(app)
 		}

--- a/cmd/burp/commands/here.go
+++ b/cmd/burp/commands/here.go
@@ -49,6 +49,7 @@ var Here = &cli.Command{
 		}
 		_ = os.Setenv(env.BurpSecret.String(), hash)
 		_ = os.Setenv(env.BurpSignature.String(), "local")
+		_ = os.Setenv(env.AgentMode.String(), "local")
 
 		secrets := &api.Secrets{
 			Server:    "https://localhost:8875",


### PR DESCRIPTION
This disables the request logger when the agent is in `local` mode which is what `burp here` uses.
Closes  #3 