### PR TITLE
[FEATURE] Simpler functional callss

### DIFF
--- a/examples/burp.toml
+++ b/examples/burp.toml
@@ -27,7 +27,7 @@ volumes = [
 
 [dependencies.environment]
 MONGO_INITDB_ROOT_USERNAME="root"
-MONGO_INITDB_ROOT_PASSWORD="[burp: Random(256) AS mongo.password]"
+MONGO_INITDB_ROOT_PASSWORD="[burp.Random(256) AS mongo.password]"
 
 #--------------------------
 # In this example, we have enabled server-side translations for .env file.
@@ -43,8 +43,8 @@ override = false
 server-side = true
 
 [environment.replacements]
-MONGO_URI="mongodb://root:[burp: Use(mongo.password)]@172.17.0.1:2732"
-SIGNING_KEY="[burp: Random(256)]"
+MONGO_URI="mongodb://root:[burp.mongo.password]@172.17.0.1:2732"
+SIGNING_KEY="[burp.Random(256)]"
 
 [[volumes]]
 name="mongo"

--- a/internal/burper/bytes.go
+++ b/internal/burper/bytes.go
@@ -1,9 +1,9 @@
 package burper
 
-var SeperatorKey = []byte{':'}
+var SeperatorKey = []byte{'.'}
 var NewlineKey = []byte{'\n'}
 var AsToken = []byte{'A', 'S'}
-var CompletePrefixKey = []byte{'b', 'u', 'r', 'p', ':'}
+var CompletePrefixKey = []byte{'b', 'u', 'r', 'p', '.'}
 
 var CommentKey = []byte{'#'}
 var EqualsKey = []byte{'='}

--- a/internal/burper/function.go
+++ b/internal/burper/function.go
@@ -24,9 +24,9 @@ func Add(function Function) bool {
 
 // Exec calls the function that was being called in the Burper statement.
 func (call *FunctionCall) Exec(line []byte, flow *Flow) ([]byte, error) {
-	function, exists := Functions[call.Function]
+	function, exists := Functions[call.Identifier]
 	if !exists {
-		return nil, errors.New("cannot find any function named " + call.Function)
+		return nil, errors.New("cannot find any function named " + call.Identifier)
 	}
 	value, err := function.Transformer(call, flow)
 	if err != nil {

--- a/internal/burper/functions_errors.go
+++ b/internal/burper/functions_errors.go
@@ -19,7 +19,7 @@ func (call *FunctionCall) MissingArgumentErr(argsType ...string) error {
 }
 
 func (call *FunctionCall) Err(message string) error {
-	return errors.New(message + " in " + call.Function + " call on \"" + string(call.Source.Match) + "\"")
+	return errors.New(message + " in " + call.Identifier + " call on \"" + string(call.Source.Match) + "\"")
 }
 
 func (call *FunctionCall) FormatErr(err error) error {

--- a/internal/burper/parser.go
+++ b/internal/burper/parser.go
@@ -76,6 +76,7 @@ func extractFunctionCalls(match *matchedFunctionCall) (*FunctionCall, error) {
 	argsOpenIndex := 0
 
 	stack, end := 0, 0
+	hasParenthesis := false
 	for index, char := range callText {
 		index, char := index, char
 		if char == '(' {
@@ -88,6 +89,7 @@ func extractFunctionCalls(match *matchedFunctionCall) (*FunctionCall, error) {
 		if char == ')' {
 			stack--
 			if stack == 0 {
+				hasParenthesis = true
 				args = callText[argsOpenIndex:index]
 			}
 			continue
@@ -109,7 +111,12 @@ func extractFunctionCalls(match *matchedFunctionCall) (*FunctionCall, error) {
 		functionCall.As = utils.Ptr(string(components[size]))
 	}
 	functionCall.Function = string(bytes.ToLower(utils.Cut(components[0], '(')))
-	functionCall.Args = extractFunctionArguments(args)
+	if hasParenthesis {
+		functionCall.Args = extractFunctionArguments(args)
+	} else {
+		functionCall.Args = []string{functionCall.Function}
+		functionCall.Function = "use"
+	}
 	return &functionCall, nil
 }
 

--- a/internal/burper/parser.go
+++ b/internal/burper/parser.go
@@ -24,10 +24,10 @@ func parse(line []byte) ([]FunctionCall, error) {
 }
 
 type FunctionCall struct {
-	Source   *matchedFunctionCall
-	Function string
-	Args     []string
-	As       *string
+	Source     *matchedFunctionCall
+	Identifier string
+	Args       []string
+	As         *string
 }
 
 type matchedFunctionCall struct {
@@ -62,7 +62,7 @@ func extractFunctionCalls(match *matchedFunctionCall) (*FunctionCall, error) {
 	if !utils.HasPrefix(match.Match, CompletePrefixKey) {
 		return nil, ErrMalformedBurpCall
 	}
-	// Splits "burp:" and "Function(args)" apart which leaves us with two parts.
+	// Splits "burp:" and "Identifier(args)" apart which leaves us with two parts.
 	parts := bytes.SplitN(match.Match, SeperatorKey, 2)
 	if len(parts) != 2 {
 		return nil, ErrMalformedBurpCall
@@ -110,12 +110,12 @@ func extractFunctionCalls(match *matchedFunctionCall) (*FunctionCall, error) {
 	if size > 1 && bytes.EqualFold(components[size-1], AsToken) {
 		functionCall.As = utils.Ptr(string(components[size]))
 	}
-	functionCall.Function = string(bytes.ToLower(utils.Cut(components[0], '(')))
+	functionCall.Identifier = string(bytes.ToLower(utils.Cut(components[0], '(')))
 	if hasParenthesis {
 		functionCall.Args = extractFunctionArguments(args)
 	} else {
-		functionCall.Args = []string{functionCall.Function}
-		functionCall.Function = "use"
+		functionCall.Args = []string{functionCall.Identifier}
+		functionCall.Identifier = "use"
 	}
 	return &functionCall, nil
 }

--- a/internal/burper/parser_test.go
+++ b/internal/burper/parser_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	calls, err := parse([]byte("REDIS_PASSWORD=\"[burp: Random(6) AS redis_pass][burp: Use(redis_pass)]\""))
+	calls, err := parse([]byte("REDIS_PASSWORD=\"[burp.Random(6) AS redis_pass][burp.redis_pass]\""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestParse(t *testing.T) {
 
 func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := parse([]byte("REDIS_PASSWORD=\"[burp: Random(6) AS redis_pass][burp: Use(redis_pass)]\""))
+		_, err := parse([]byte("REDIS_PASSWORD=\"[burp.Random(6) AS redis_pass][burp.redis_pass]\""))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/burper/parser_test.go
+++ b/internal/burper/parser_test.go
@@ -10,8 +10,8 @@ func TestParse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if calls[0].Function != "random" {
-		t.Fatal(errors.New("function is not being parsed, expected calls[0].Function to be \"random\""))
+	if calls[0].Identifier != "random" {
+		t.Fatal(errors.New("function is not being parsed, expected calls[0].Identifier to be \"random\""))
 	}
 	if len(calls[0].Args) != 1 {
 		t.Fatal(errors.New("function is not being parsed, expected len(calls[0].Args) to be 1"))
@@ -19,8 +19,8 @@ func TestParse(t *testing.T) {
 	if calls[0].Args[0] != "6" {
 		t.Fatal(errors.New("function is not being parsed, expected calls[0].Args[0] to be \"6\""))
 	}
-	if calls[1].Function != "use" {
-		t.Fatal(errors.New("function is not being parsed, expected calls[1].Function to be \"use\""))
+	if calls[1].Identifier != "use" {
+		t.Fatal(errors.New("function is not being parsed, expected calls[1].Identifier to be \"use\""))
 	}
 	if len(calls[1].Args) != 1 {
 		t.Fatal(errors.New("function is not being parsed, expected len(calls[1].Args) to be 1"))


### PR DESCRIPTION
This PR adds a simpler way to use stored values and also a more familiar way of calling functions. In this change, we change the function calls from: `burp: Function(args)` to `burp.Function(args)`, in addition, this change adds support for assuming we want to use the `Use` function when we don't add args (similar to variables),  for example, the following: `burp: Use(mongo.pass)` would now be `burp.mongo.pass` or `burp: Use(redis_pass)` would be `burp.redis_pass`.